### PR TITLE
Minor improvement to Basal's documentation

### DIFF
--- a/basal/index.html
+++ b/basal/index.html
@@ -48,8 +48,8 @@
 <ul>
 <li><strong>Tune</strong>: offsets the V/OCT input one octave up or down.</li>
 <li><strong>Oct</strong>: offsets the V/OCT input three octaves up and down.</li>
-<li><strong>Mod 1</strong>: creates overtones by distorting the phase of the main oscillator.</li>
-<li><strong>Mod 2</strong>: increases the number of harmonics.</li>
+<li><strong>Mod 1</strong>: creates overtones by distorting the phase of the main oscillator (-10V to +10V). The CV input is attenuverted according to the smaller encoder and then added to Mod 1.</li>
+<li><strong>Mod 2</strong>: increases the number of harmonics (-10V to +10V). The CV input is attenuverted according to the smaller encoder and then added to Mod 2.</li>
 <li><strong>V/OCT</strong>: this is the main input of the oscillator. It defines the pitch using the 1V per octave convention. Zero volts corresponds to a C3 note.</li>
 <li><strong>Out</strong>: main output of the oscillator.</li>
 </ul>


### PR DESCRIPTION
Added the voltage represented by the Mod 1 and 2 encoders and how the CV input and related attenuverters behave. Hope I got it right from my experiments 😀